### PR TITLE
Added karaf/rest_beanvalidation example 

### DIFF
--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -27,6 +27,7 @@
 		<module>properties</module>
 		<module>properties_encryption</module>
 		<module>rest</module>
+		<module>rest_beanvalidation</module>
 		<module>rest_dsl</module>
 		<module>rest_dsl_basic_auth</module>
 		<module>rest_dsl_simple</module>

--- a/karaf/rest_beanvalidation/README.md
+++ b/karaf/rest_beanvalidation/README.md
@@ -1,0 +1,62 @@
+Rest CXF RS and bean validation Camel OSGi example
+====================================
+ This project demonstrates how to publish a  Webservice using CXF RS and validate the input with bean validation. It also has seperate routes that demonstrate how to call a the cxf rs endpoint and also how to receive the request and process it.
+ Take note of the fact that the interface and his implementation are used ONLY for service definition, not implementation (i.e. the implementation method never get called). The implementation of the rest service must be called explicitly from the route iteself.
+ 
+### Requirements:
+ * JBoss Fuse 6.2.1
+ * Maven 3.0 or Greater (http://maven.apache.org/)
+ * Java 8
+ 
+Building
+-----------------------
+ 
+To build the project. 
+ 
+	mvn clean install
+ 
+This will build the bundle including the manifest information. 
+
+Deploying to JBoss Fuse
+-----------------------
+ 
+To start up Fuse Karaf browse to your fuse install directory. Then run
+     
+	/bin/fuse
+
+This will bring up the fuse console.  Once in the console you will be able to install your bundle.
+Usually we would install multiple bundles using a feature file, but in this case since we only have one bundle to install we can just install it using the file by the following command. Another option is to set up your local m2 repository in fuse in the fuse/etc/org.ops4j.pax.url.mvn.cfg file.  Then you can use the mvn syntax below.
+
+	admin@root> features:install cxf-bean-validation hibernate-validator cxf-jaxrs
+    admin@root> osgi:install -s mvn:com.redhat.consulting.fusequickstarts.karaf/rest-beanvalidation/6.2.1
+        OR
+    admin@root> features:install cxf-bean-validation hibernate-validator cxf-jaxrs
+    admin@root> osgi:install -s file:/home/yourUser/.m2/repository/com/redhat/consulting/fusequickstarts/karaf/rest-beanvalidation-6.2.1.jar
+ 
+The -s here indicates to also start the bundle.  Alternatively you can omit the -s and after the install run
+    
+	karaf@root> osgi:start <bundleId>
+
+Testing
+-----------------------
+After you deploy the route you can confirm that the endpoints are deployed and working by checking the log for the following output:
+
+21:12:22,118 | INFO  | tp1296672062-339 | LoggingInInterceptor             | 118 - org.apache.cxf.cxf-core - 3.0.4.redhat-620133 | Inbound Message
+
+ID: 5897
+Address: http://localhost:8183/service/1
+Http-Method: GET
+Content-Type: */*
+Headers: {Accept=[application/json,application/xml], breadcrumbId=[ID-dhcp-192-168-141-42-40384-1447969596266-17-41], Cache-Control=[no-cache], connection=[keep-alive], content-type=[*/*], firedTime=[Thu N      ov 19 21:12:22 EST 2015], Host=[localhost:8183], Pragma=[no-cache], User-Agent=[Apache CXF 3.0.4.redhat-620133]}
+
+21:12:22,118 | INFO  | tp1296672062-339 | route35                          | 198 - org.apache.camel.camel-core - 2.15.1.redhat-620133 | Request Recieved
+21:12:22,119 | INFO  | tp1296672062-339 | LoggingOutInterceptor            | 118 - org.apache.cxf.cxf-core - 3.0.4.redhat-620133 | Outbound Message
+
+ID: 5897
+Response-Code: 200
+Content-Type: application/json
+Headers: {Content-Type=[application/json], Date=[Fri, 20 Nov 2015 02:12:22 GMT]}
+Payload: Sample User
+
+you will also see some errors because not all the auto generated requests will succeed, aproxymately half of them will be rejected because of failing the validation. According to the regex validation pattern in the service interface the url parameter part should be numeric and begin with '1'. You can verify that also using Camel tab of Hawtaio console at http://localhost:8181.
+

--- a/karaf/rest_beanvalidation/pom.xml
+++ b/karaf/rest_beanvalidation/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.redhat.consulting.fusequickstarts.karaf</groupId>
+    <artifactId>karaf-parent</artifactId>
+    <version>6.2.1</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>rest-beanvalidation</artifactId>
+  <name>Fuse Quickstart :: Karaf :: Blueprint :: OSGI Rest with beanvalidation</name>
+  <packaging>bundle</packaging>
+    <!-- Any dependencies needed by your project -->
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-http4</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-cxf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-transports-http-jetty</artifactId>
+    </dependency>
+    <!-- This is needed to beanvalidation -->
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>1.1.0.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.el</groupId>
+      <artifactId>javax.el-api</artifactId>
+      <!-- use 3.0-b02 version for Java 6 -->
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.el</artifactId>
+      <!-- explicitly use 3.0-b01 version for Java 6 -->
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <version>5.0.3.Final</version>
+    </dependency>
+  </dependencies>
+
+  <!-- This is needed to get the Restlet Deps -->
+  <repositories>
+    <repository>
+      <id>maven-restlet</id>
+      <name>Public online Restlet repository</name>
+      <url>http://maven.restlet.org</url>
+    </repository>
+  </repositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+            <!-- Bundle plugin which builds the bundle to install on karaf -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <manifestLocation>target/META-INF</manifestLocation>
+          <instructions>
+            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+            <!-- Any packages to be exported for use by another bundle -->
+            <Export-Package />
+            <!-- Any packages needed by your bundle -->
+            <Import-Package>
+              org.apache.camel.*,
+              org.osgi.service.*,
+              org.apache.cxf.jaxrs.client,
+              org.apache.cxf.*,
+              javax.ws.rs,
+              javax.ws.rs.core,
+              net.sf.cglib.proxy,
+              net.sf.cglib.core,
+              javax.validation.*,
+              org.hibernate.validator.*,
+              com.fasterxml.*
+            </Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/processor/InvalidFiftyPercentOfTimesRequestProcessor.java
+++ b/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/processor/InvalidFiftyPercentOfTimesRequestProcessor.java
@@ -1,0 +1,40 @@
+package com.redhat.consulting.fusequickstarts.karaf.rest.beanvalidation.processor;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.component.cxf.common.message.CxfConstants;
+import org.apache.cxf.message.MessageContentsList;
+
+import java.util.Random;
+
+public class InvalidFiftyPercentOfTimesRequestProcessor implements Processor {
+
+    public void process(Exchange exchange) throws Exception {
+
+        Random r = new Random();
+        float chance = r.nextFloat();
+
+        exchange.setPattern(ExchangePattern.InOut);
+        Message inMessage = exchange.getIn();
+        // set the operation name
+        inMessage.setHeader(CxfConstants.OPERATION_NAME, "getSampleUser");
+        // using the proxy client API
+        inMessage.setHeader(CxfConstants.CAMEL_CXF_RS_USING_HTTP_API, Boolean.FALSE);
+        // creating the request
+        MessageContentsList req = new MessageContentsList();
+
+        if (chance <= 0.50f) {
+            // setting id which doesn't start with 1 (i.e. not in pattern: regexp = "^1[0-9]*$")
+            req.add("25");
+        } else {
+            // setting id which start with one (i.e. pattern: regexp = "^1[0-9]*$")
+            req.add("11");
+        }
+
+        inMessage.setBody(req);
+
+    }
+
+}

--- a/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/processor/MyServiceImpl.java
+++ b/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/processor/MyServiceImpl.java
@@ -1,0 +1,12 @@
+package com.redhat.consulting.fusequickstarts.karaf.rest.beanvalidation.processor;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.camel.Exchange;
+
+public class MyServiceImpl {
+
+    public void getSampleUser(Exchange exchange) throws Exception {
+        exchange.getOut().setBody(Response.status(Response.Status.OK).entity("Sample User").build());
+    }
+}

--- a/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/processor/RequestProcessor.java
+++ b/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/processor/RequestProcessor.java
@@ -1,0 +1,27 @@
+package com.redhat.consulting.fusequickstarts.karaf.rest.beanvalidation.processor;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.component.cxf.common.message.CxfConstants;
+import org.apache.cxf.message.MessageContentsList;
+
+public class RequestProcessor implements Processor {
+
+    public void process(Exchange exchange) throws Exception {
+        exchange.setPattern(ExchangePattern.InOut);
+        Message inMessage = exchange.getIn();
+        // set the operation name
+        inMessage.setHeader(CxfConstants.OPERATION_NAME, "getSampleUser");
+        // using the proxy client API
+        inMessage.setHeader(CxfConstants.CAMEL_CXF_RS_USING_HTTP_API, Boolean.FALSE);
+        // creating the request
+        MessageContentsList req = new MessageContentsList();
+        // setting id which start with one (i.e. pattern: regexp = "^1[0-9]*$")
+        req.add("1");
+        inMessage.setBody(req);
+
+    }
+
+}

--- a/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/resolver/HibernateValidationProviderResolver.java
+++ b/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/resolver/HibernateValidationProviderResolver.java
@@ -1,0 +1,23 @@
+package com.redhat.consulting.fusequickstarts.karaf.rest.beanvalidation.resolver;
+
+import org.hibernate.validator.HibernateValidator;
+
+import javax.validation.ValidationProviderResolver;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * OSGi-friendly implementation of {@code javax.validation.ValidationProviderResolver} returning
+ * {@code org.hibernate.validator.HibernateValidator} instance.
+ *
+ */
+public class HibernateValidationProviderResolver implements ValidationProviderResolver
+{
+   @SuppressWarnings("unchecked")
+   @Override
+   public List getValidationProviders()
+   {
+      return singletonList(new HibernateValidator());
+   }
+}

--- a/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/resource/MyResource.java
+++ b/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/resource/MyResource.java
@@ -1,0 +1,19 @@
+package com.redhat.consulting.fusequickstarts.karaf.rest.beanvalidation.resource;
+
+import javax.validation.constraints.Pattern;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/service")
+public interface MyResource {
+
+    @GET
+    @Path("/{id}")
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public Response getSampleUser(@PathParam("id") @Pattern(regexp = "^1[0-9]*$") String id);
+
+}

--- a/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/resource/MyResourceImpl.java
+++ b/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/resource/MyResourceImpl.java
@@ -1,0 +1,15 @@
+package com.redhat.consulting.fusequickstarts.karaf.rest.beanvalidation.resource;
+
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import javax.validation.constraints.Pattern;
+import javax.ws.rs.core.Response;
+
+public class MyResourceImpl implements MyResource {
+
+    @Override
+    public Response getSampleUser(@Pattern(regexp = "^1[0-9]*$") String id) {
+        //XXX: you should never reach here
+        throw new UnsupportedOperationException("You should never reach here!");
+    }
+}

--- a/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/route/EndpointRoute.java
+++ b/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/route/EndpointRoute.java
@@ -1,0 +1,31 @@
+package com.redhat.consulting.fusequickstarts.karaf.rest.beanvalidation.route;
+
+import com.redhat.consulting.fusequickstarts.karaf.rest.beanvalidation.processor.MyServiceImpl;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.cxf.common.message.CxfConstants;
+
+/*
+ * The route for receiving requests from out cxf endpoints.
+ */
+
+public class EndpointRoute extends RouteBuilder {
+
+    private MyServiceImpl myServiceImpl = new MyServiceImpl();
+
+    @Override
+    public void configure() throws Exception {
+        // @formatter:off
+        
+        from("cxfrs:bean:rsServer?bindingStyle=SimpleConsumer")
+            .routeId("restEndpointConsumer")
+            .choice() //selects what to do based on the request
+                .when(header(CxfConstants.OPERATION_NAME).isEqualTo("getSampleUser"))
+                    .bean(myServiceImpl, "getSampleUser")
+                    .log(LoggingLevel.INFO, "Request Recieved") 
+                .otherwise()
+                    .log(LoggingLevel.WARN, "Unknown Method");
+
+    }
+
+}

--- a/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/route/RequestRoute.java
+++ b/karaf/rest_beanvalidation/src/main/java/com/redhat/consulting/fusequickstarts/karaf/rest/beanvalidation/route/RequestRoute.java
@@ -1,0 +1,24 @@
+package com.redhat.consulting.fusequickstarts.karaf.rest.beanvalidation.route;
+
+import com.redhat.consulting.fusequickstarts.karaf.rest.beanvalidation.processor.InvalidFiftyPercentOfTimesRequestProcessor;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.builder.RouteBuilder;
+
+/*
+ * The route for sending requests to our cxf endpoint
+ */
+public class RequestRoute extends RouteBuilder {
+
+    private final InvalidFiftyPercentOfTimesRequestProcessor requestProcessor = new InvalidFiftyPercentOfTimesRequestProcessor();
+
+    @Override
+    public void configure() throws Exception {
+        // @formatter:off
+        
+        from("timer://restRequestTimer?period=5000") //period in milliseconds
+            .routeId("restEndpointTestProducer")
+            .log(LoggingLevel.INFO, "Starting request")
+            .process(requestProcessor) //set the appropriate headers
+            .to("cxfrs://bean://rsClient");
+    }
+}

--- a/karaf/rest_beanvalidation/src/main/resources/OSGI-INF/blueprint/camel-context.xml
+++ b/karaf/rest_beanvalidation/src/main/resources/OSGI-INF/blueprint/camel-context.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.0.0"
+	xmlns:jaxws="http://cxf.apache.org/blueprint/jaxws" xmlns:camel="http://camel.apache.org/schema/blueprint"
+    xmlns:cxf="http://camel.apache.org/schema/blueprint/cxf" xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
+	xsi:schemaLocation="
+             http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+             http://camel.apache.org/schema/cxf http://camel.apache.org/schema/cxf/camel-cxf.xsd
+             http://cxf.apache.org/blueprint/jaxws http://cxf.apache.org/schemas/blueprint/jaxws.xsd
+             http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd
+             http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd
+             ">
+
+	<!-- The camel context which registers the route -->
+	<camel:camelContext id="fusequickstart-cxf-rest"
+		xmlns="http://camel.apache.org/schema/blueprint">
+		<!-- Package Scanning finds the Routes -->
+		<packageScan>
+			<package>com.redhat.consulting.fusequickstarts.karaf.rest.beanvalidation.route</package>
+		</packageScan>
+	</camel:camelContext>
+  
+     <!-- RS Client for requests to endpoint -->
+     <cxf:rsClient id="rsClient" address="http://localhost:8183"
+                   serviceClass="com.redhat.consulting.fusequickstarts.karaf.rest.beanvalidation.resource.MyResource" loggingFeatureEnabled="true"/>
+     
+     <!-- RS Service for consuming from the endpoint -->
+     <cxf:rsServer id="rsServer" address="http://localhost:8183"
+                   loggingFeatureEnabled="true">
+
+		<cxf:serviceBeans>
+			<bean class="com.redhat.consulting.fusequickstarts.karaf.rest.beanvalidation.resource.MyResourceImpl"/>
+		</cxf:serviceBeans>
+
+		<cxf:providers>
+			<bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>
+		</cxf:providers>
+		<!-- Ban validation cxf feature -->
+		<cxf:features>
+			<bean class="org.apache.cxf.validation.BeanValidationFeature">
+				<property name="provider" ref="beanValidationProvider"/>
+			</bean>
+		</cxf:features>
+	</cxf:rsServer>
+
+	<bean id="beanValidationProvider" class="org.apache.cxf.validation.BeanValidationProvider">
+		<argument ref="validationProviderResolver"/>
+	</bean>
+
+	<!-- Ban validation resolver -->
+	<bean id="validationProviderResolver" class="com.redhat.consulting.fusequickstarts.karaf.rest.beanvalidation.resolver.HibernateValidationProviderResolver"/>
+
+</blueprint>

--- a/karaf/rest_beanvalidation/src/test/java/com/redhat/consulting/fusequickstarts/karaf/red/route/EndpointRouteTest.java
+++ b/karaf/rest_beanvalidation/src/test/java/com/redhat/consulting/fusequickstarts/karaf/red/route/EndpointRouteTest.java
@@ -1,0 +1,69 @@
+package com.redhat.consulting.fusequickstarts.karaf.red.route;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.cxf.common.message.CxfConstants;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.cxf.message.MessageContentsList;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.redhat.consulting.fusequickstarts.karaf.rest.beanvalidation.route.EndpointRoute;
+
+public class EndpointRouteTest extends CamelTestSupport {
+
+    /**
+     * Mock all the Endpoints
+     */
+    @Override
+    public String isMockEndpoints() {
+        return "*";
+    }
+
+    /**
+     * Set Routes for Testing
+     */
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new EndpointRoute();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        replaceRouteFromWith("restEndpointConsumer", "direct:restTestEndpoint");
+        super.setUp();
+    }
+
+    /**
+     * Test GET Direct Route
+     */
+    @Test
+    public void testDirectGet() {
+
+        // Send Test Message to
+        Exchange responseExchange = template.send("direct:restTestEndpoint", new Processor() {
+            public void process(Exchange exchange) {
+                exchange.setPattern(ExchangePattern.InOut);
+                Message inMessage = exchange.getIn();
+                // set the operation name
+                inMessage.setHeader(CxfConstants.OPERATION_NAME, "getSampleUser");
+                // using the proxy client API
+                inMessage.setHeader(CxfConstants.CAMEL_CXF_RS_USING_HTTP_API, Boolean.FALSE);
+                // creating the request
+                MessageContentsList req = new MessageContentsList();
+                req.add("1");
+                inMessage.setBody(req);
+            }
+        });
+
+        // Test Response
+        Assert.assertNotNull("Response was Null", responseExchange);
+
+        Message responseMessage = responseExchange.getIn();
+        Assert.assertNotNull("Response Message was Null", responseMessage);
+    }
+
+}


### PR DESCRIPTION
Using Camel osgi CXF RS and bean validation for input; thought was helpful since there is no full example on this and the documentation itself is somewhat to be interpreted.